### PR TITLE
Minor fix

### DIFF
--- a/Creative Mode/Creative Mode/CreativeMode.cs
+++ b/Creative Mode/Creative Mode/CreativeMode.cs
@@ -193,6 +193,9 @@ namespace CreativeMode
 
 		public void GetData(GetDataEventArgs e)
 		{
+			if (e.Msg.whoAmI > Main.maxNetPlayers)
+				return;
+				
 			if (playerList[e.Msg.whoAmI])
 			{
 				if (plr.Group.HasPermission("creativemode.*") || plr.Group.HasPermission("creativemode.tiles"))


### PR DESCRIPTION
When too many players are joining the server right now, GetData hook causes an System.IndexOutOfRangeException.